### PR TITLE
Update NuGet packages and remove UseStaticRegistration

### DIFF
--- a/src/Conduit/Conduit.csproj
+++ b/src/Conduit/Conduit.csproj
@@ -8,17 +8,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="7.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="4.0.1" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="7.6.103" />
-    <PackageReference Include="MediatR" Version="5.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="2.5.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="7.6.104" />
+    <PackageReference Include="MediatR" Version="5.1.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="5.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\Infrastructure.Errors.ErrorHandlingMiddleware.Designer.cs">

--- a/tests/Conduit.IntegrationTests/Conduit.IntegrationTests.csproj
+++ b/tests/Conduit.IntegrationTests/Conduit.IntegrationTests.csproj
@@ -4,9 +4,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Conduit\Conduit.csproj" />

--- a/tests/Conduit.IntegrationTests/SliceFixture.cs
+++ b/tests/Conduit.IntegrationTests/SliceFixture.cs
@@ -15,7 +15,6 @@ namespace Conduit.IntegrationTests
 
         public SliceFixture()
         {
-            AutoMapper.ServiceCollectionExtensions.UseStaticRegistration = false;
             var startup = new Startup();
             var services = new ServiceCollection();
 


### PR DESCRIPTION
After updating NuGet packages it looks as though UseStaticRegistration has been removed from `AutoMapper.Extensions.Microsoft.DependencyInjection`, and the current behavior in `5.0.1` seems to be the same as one would expect when setting `UseStaticRegistration` to `false`, so this LOC seems unnecessary now. See [this PR](https://github.com/AutoMapper/AutoMapper.Extensions.Microsoft.DependencyInjection/pull/58/files) for details.