### PR TITLE
Upgrade Mediatr library

### DIFF
--- a/src/Conduit/Conduit.csproj
+++ b/src/Conduit/Conduit.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.1.3" />
-    <PackageReference Include="MediatR" Version="6.0.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="MediatR" Version="7.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conduit/Startup.cs
+++ b/src/Conduit/Startup.cs
@@ -17,6 +17,7 @@ using Swashbuckle.AspNetCore.Swagger;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Conduit
 {
@@ -36,7 +37,7 @@ namespace Conduit
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMediatR();
+            services.AddMediatR(Assembly.GetExecutingAssembly());
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationPipelineBehavior<,>));
             services.AddScoped(typeof(IPipelineBehavior<,>), typeof(DBContextTransactionPipelineBehavior<,>));
 


### PR DESCRIPTION
Hi there!

I've created a couple of changes related to Mediatr library. The new version of Mediart doesn't accept the empty constructor. I have added a parameter to Mediatr dependency call inside the `ConfigureServices` method. 

Just let me know if I need to revise something. Thanks!